### PR TITLE
Fix the process of loading versions

### DIFF
--- a/source/bindbc/opengl/bind/gl12.d
+++ b/source/bindbc/opengl/bind/gl12.d
@@ -69,21 +69,18 @@ __gshared {
 }
 
 package(bindbc.opengl) @nogc nothrow
-GLSupport loadGL12(SharedLib lib, GLSupport contextVersion)
+bool loadGL12(SharedLib lib, GLSupport contextVersion)
 {
-    auto loadedVersion = GLSupport.gl11;
-
     if(contextVersion > GLSupport.gl11) {
         lib.bindGLSymbol(cast(void**)&glDrawRangeElements, "glDrawRangeElements");
         lib.bindGLSymbol(cast(void**)&glTexImage3D, "glTexImage3D");
         lib.bindGLSymbol(cast(void**)&glTexSubImage3D, "glTexSubImage3D");
         lib.bindGLSymbol(cast(void**)&glCopyTexSubImage3D, "glCopyTexSubImage3D");
 
-        immutable res = errorCountGL() == 0;
-        version(GL_AllowDeprecated) {
-            if(res && loadDeprecatedGL12(lib)) loadedVersion = GLSupport.gl12;
+        if(errorCountGL() == 0) {
+            version(GL_AllowDeprecated) return loadDeprecatedGL12(lib);
+            else return true;
         }
-        else if(res) loadedVersion = GLSupport.gl12;
     }
-    return loadedVersion;
+    return false;
 }

--- a/source/bindbc/opengl/bind/gl13.d
+++ b/source/bindbc/opengl/bind/gl13.d
@@ -103,10 +103,9 @@ __gshared {
 }
 
 package(bindbc.opengl) @nogc nothrow
-GLSupport loadGL13(SharedLib lib, GLSupport contextVersion)
+bool loadGL13(SharedLib lib, GLSupport contextVersion)
 {
-    auto loadedVersion = loadGL12(lib, contextVersion);
-    if(loadedVersion == GLSupport.gl12 && contextVersion > GLSupport.gl12) {
+    if(contextVersion > GLSupport.gl12) {
         lib.bindGLSymbol(cast(void**)&glActiveTexture, "glActiveTexture");
         lib.bindGLSymbol(cast(void**)&glSampleCoverage, "glSampleCoverage");
         lib.bindGLSymbol(cast(void**)&glCompressedTexImage3D, "glCompressedTexImage3D");
@@ -117,11 +116,10 @@ GLSupport loadGL13(SharedLib lib, GLSupport contextVersion)
         lib.bindGLSymbol(cast(void**)&glCompressedTexSubImage1D, "glCompressedTexSubImage1D");
         lib.bindGLSymbol(cast(void**)&glGetCompressedTexImage, "glGetCompressedTexImage");
 
-        immutable res = errorCountGL() == 0;
-        version(GL_AllowDeprecated) {
-            if(res && lib.loadDeprecatedGL13()) loadedVersion = GLSupport.gl13;
+        if(errorCountGL() == 0) {
+            version(GL_AllowDeprecated) return loadDeprecatedGL13(lib);
+            else return true;
         }
-        else if(res) loadedVersion = GLSupport.gl13;
     }
-    return loadedVersion;
+    return false;
 }

--- a/source/bindbc/opengl/bind/gl14.d
+++ b/source/bindbc/opengl/bind/gl14.d
@@ -68,10 +68,9 @@ __gshared {
 }
 
 package(bindbc.opengl) @nogc nothrow
-GLSupport loadGL14(SharedLib lib, GLSupport contextVersion)
+bool loadGL14(SharedLib lib, GLSupport contextVersion)
 {
-    auto loadedVersion = loadGL13(lib, contextVersion);
-    if(loadedVersion == GLSupport.gl13 && contextVersion > GLSupport.gl13) {
+    if(contextVersion > GLSupport.gl13) {
         lib.bindGLSymbol(cast(void**)&glBlendFuncSeparate, "glBlendFuncSeparate");
         lib.bindGLSymbol(cast(void**)&glMultiDrawArrays, "glMultiDrawArrays");
         lib.bindGLSymbol(cast(void**)&glMultiDrawElements, "glMultiDrawElements");
@@ -82,11 +81,10 @@ GLSupport loadGL14(SharedLib lib, GLSupport contextVersion)
         lib.bindGLSymbol(cast(void**)&glBlendColor, "glBlendColor");
         lib.bindGLSymbol(cast(void**)&glBlendEquation, "glBlendEquation");
 
-        immutable res = errorCountGL() == 0;
-        version(GL_AllowDeprecated) {
-            if(res && lib.loadDeprecatedGL14()) loadedVersion = GLSupport.gl14;
+        if(errorCountGL() == 0) {
+            version(GL_AllowDeprecated) return loadDeprecatedGL14(lib);
+            else return true;
         }
-        else if(res) loadedVersion = GLSupport.gl14;
     }
-    return loadedVersion;
+    return false;
 }

--- a/source/bindbc/opengl/bind/gl15.d
+++ b/source/bindbc/opengl/bind/gl15.d
@@ -88,10 +88,9 @@ __gshared {
 }
 
 package(bindbc.opengl) @nogc nothrow
-GLSupport loadGL15(SharedLib lib, GLSupport contextVersion)
+bool loadGL15(SharedLib lib, GLSupport contextVersion)
 {
-    auto loadedVersion = loadGL14(lib, contextVersion);
-    if(loadedVersion == GLSupport.gl14 && contextVersion > GLSupport.gl14) {
+    if(contextVersion > GLSupport.gl14) {
         lib.bindGLSymbol(cast(void**)&glGenQueries, "glGenQueries");
         lib.bindGLSymbol(cast(void**)&glDeleteQueries, "glDeleteQueries");
         lib.bindGLSymbol(cast(void**)&glIsQuery, "glIsQuery");
@@ -111,7 +110,7 @@ GLSupport loadGL15(SharedLib lib, GLSupport contextVersion)
         lib.bindGLSymbol(cast(void**)&glUnmapBuffer, "glUnmapBuffer");
         lib.bindGLSymbol(cast(void**)&glGetBufferParameteriv, "glGetBufferParameteriv");
         lib.bindGLSymbol(cast(void**)&glGetBufferPointerv, "glGetBufferPointerv");
-        if(errorCountGL() == 0) loadedVersion = GLSupport.gl15;
+        if(errorCountGL() == 0) return true;
     }
-    return loadedVersion;
+    return false;
 }

--- a/source/bindbc/opengl/bind/gl20.d
+++ b/source/bindbc/opengl/bind/gl20.d
@@ -291,10 +291,9 @@ __gshared {
 }
 
 package(bindbc.opengl) @nogc nothrow
-GLSupport loadGL20(SharedLib lib, GLSupport contextVersion)
+bool loadGL20(SharedLib lib, GLSupport contextVersion)
 {
-    auto loadedVersion = loadGL15(lib, contextVersion);
-    if(loadedVersion == GLSupport.gl15 && contextVersion > GLSupport.gl15) {
+    if(contextVersion > GLSupport.gl15) {
         lib.bindGLSymbol(cast(void**)&glBlendEquationSeparate, "glBlendEquationSeparate");
         lib.bindGLSymbol(cast(void**)&glDrawBuffers, "glDrawBuffers");
         lib.bindGLSymbol(cast(void**)&glStencilOpSeparate, "glStencilOpSeparate");
@@ -388,7 +387,7 @@ GLSupport loadGL20(SharedLib lib, GLSupport contextVersion)
         lib.bindGLSymbol(cast(void**)&glVertexAttrib4uiv, "glVertexAttrib4uiv");
         lib.bindGLSymbol(cast(void**)&glVertexAttrib4usv, "glVertexAttrib4usv");
         lib.bindGLSymbol(cast(void**)&glVertexAttribPointer, "glVertexAttribPointer");
-        if(errorCountGL() == 0) loadedVersion = GLSupport.gl20;
+        if(errorCountGL() == 0) return true;
     }
-    return loadedVersion;
+    return false;
 }

--- a/source/bindbc/opengl/bind/gl21.d
+++ b/source/bindbc/opengl/bind/gl21.d
@@ -53,17 +53,16 @@ __gshared {
 }
 
 package(bindbc.opengl) @nogc nothrow
-GLSupport loadGL21(SharedLib lib, GLSupport contextVersion)
+bool loadGL21(SharedLib lib, GLSupport contextVersion)
 {
-    auto loadedVersion = loadGL20(lib, contextVersion);
-    if(loadedVersion == GLSupport.gl20 && contextVersion > GLSupport.gl20) {
+    if(contextVersion > GLSupport.gl20) {
         lib.bindGLSymbol(cast(void**)&glUniformMatrix2x3fv, "glUniformMatrix2x3fv");
         lib.bindGLSymbol(cast(void**)&glUniformMatrix3x2fv, "glUniformMatrix3x2fv");
         lib.bindGLSymbol(cast(void**)&glUniformMatrix2x4fv, "glUniformMatrix2x4fv");
         lib.bindGLSymbol(cast(void**)&glUniformMatrix4x2fv, "glUniformMatrix4x2fv");
         lib.bindGLSymbol(cast(void**)&glUniformMatrix3x4fv, "glUniformMatrix3x4fv");
         lib.bindGLSymbol(cast(void**)&glUniformMatrix4x3fv, "glUniformMatrix4x3fv");
-        if(errorCountGL() == 0) loadedVersion = GLSupport.gl21;
+        if(errorCountGL() == 0) return true;
     }
-    return loadedVersion;
+    return false;
 }

--- a/source/bindbc/opengl/bind/gl30.d
+++ b/source/bindbc/opengl/bind/gl30.d
@@ -241,7 +241,7 @@ static if(glSupport >= GLSupport.gl30) {
     }
 
     package(bindbc.opengl) @nogc nothrow
-    GLSupport loadGL30(SharedLib lib, GLSupport contextVersion)
+    bool loadGL30(SharedLib lib, GLSupport contextVersion)
     {
         import bindbc.opengl.bind.arb : loadARB30;
 
@@ -305,8 +305,8 @@ static if(glSupport >= GLSupport.gl30) {
             lib.bindGLSymbol(cast(void**)&glClearBufferfi, "glClearBufferfi");
             lib.bindGLSymbol(cast(void**)&glGetStringi, "glGetStringi");
 
-            if(errorCountGL() == 0 && loadARB30(lib, contextVersion)) return GLSupport.gl30;
+            if(errorCountGL() == 0 && loadARB30(lib, contextVersion)) return true;
         }
-        return GLSupport.gl21;
+        return false;
     }
 }

--- a/source/bindbc/opengl/bind/gl31.d
+++ b/source/bindbc/opengl/bind/gl31.d
@@ -61,7 +61,7 @@ static if(glSupport >= GLSupport.gl31) {
     }
 
     package(bindbc.opengl) @nogc nothrow
-    GLSupport loadGL31(SharedLib lib, GLSupport contextVersion)
+    bool loadGL31(SharedLib lib, GLSupport contextVersion)
     {
         import bindbc.opengl.bind.arb : loadARB31;
 
@@ -71,8 +71,8 @@ static if(glSupport >= GLSupport.gl31) {
             lib.bindGLSymbol(cast(void**)&glTexBuffer, "glTexBuffer");
             lib.bindGLSymbol(cast(void**)&glPrimitiveRestartIndex, "glPrimitiveRestartIndex");
 
-            if(errorCountGL() == 0 && loadARB31(lib, contextVersion)) return GLSupport.gl31;
+            if(errorCountGL() == 0 && loadARB31(lib, contextVersion)) return true;
         }
-        return GLSupport.gl30;
+        return false;
     }
 }

--- a/source/bindbc/opengl/bind/gl32.d
+++ b/source/bindbc/opengl/bind/gl32.d
@@ -50,7 +50,7 @@ static if(glSupport >= GLSupport.gl32) {
     }
 
     package(bindbc.opengl) @nogc nothrow
-    GLSupport loadGL32(SharedLib lib, GLSupport contextVersion)
+    bool loadGL32(SharedLib lib, GLSupport contextVersion)
     {
         import bindbc.opengl.bind.arb : loadARB32;
 
@@ -59,8 +59,8 @@ static if(glSupport >= GLSupport.gl32) {
             lib.bindGLSymbol(cast(void**)&glGetBufferParameteri64v, "glGetBufferParameteri64v");
             lib.bindGLSymbol(cast(void**)&glFramebufferTexture, "glFramebufferTexture");
 
-            if(errorCountGL() == 0 && loadARB32(lib, contextVersion)) return GLSupport.gl32;
+            if(errorCountGL() == 0 && loadARB32(lib, contextVersion)) return true;
         }
-        return GLSupport.gl31;
+        return false;
     }
 }

--- a/source/bindbc/opengl/bind/gl33.d
+++ b/source/bindbc/opengl/bind/gl33.d
@@ -17,14 +17,14 @@ static if(glSupport >= GLSupport.gl33) {
     __gshared da_glVertexAttribDivisor glVertexAttribDivisor;
 
     package(bindbc.opengl) @nogc nothrow
-    GLSupport loadGL33(SharedLib lib, GLSupport contextVersion)
+    bool loadGL33(SharedLib lib, GLSupport contextVersion)
     {
         import bindbc.opengl.bind.arb : loadARB33;
 
         if(contextVersion >= GLSupport.gl33) {
             lib.bindGLSymbol(cast(void**)&glVertexAttribDivisor, "glVertexAttribDivisor");
-            if(errorCountGL() == 0 && loadARB33(lib, contextVersion)) return GLSupport.gl33;
+            if(errorCountGL() == 0 && loadARB33(lib, contextVersion)) return true;
         }
-        return GLSupport.gl32;
+        return false;
     }
 }

--- a/source/bindbc/opengl/bind/gl40.d
+++ b/source/bindbc/opengl/bind/gl40.d
@@ -43,7 +43,7 @@ static if(glSupport >= GLSupport.gl40) {
     }
 
     package(bindbc.opengl) @nogc nothrow
-    GLSupport loadGL40(SharedLib lib, GLSupport contextVersion)
+    bool loadGL40(SharedLib lib, GLSupport contextVersion)
     {
         import bindbc.opengl.bind.arb : loadARB40;
 
@@ -54,8 +54,8 @@ static if(glSupport >= GLSupport.gl40) {
             lib.bindGLSymbol(cast(void**)&glBlendFunci, "glBlendFunci");
             lib.bindGLSymbol(cast(void**)&glBlendFuncSeparatei, "glBlendFuncSeparatei");
 
-            if(errorCountGL() == 0 && loadARB40(lib, contextVersion)) return GLSupport.gl40;
+            if(errorCountGL() == 0 && loadARB40(lib, contextVersion)) return true;
         }
-        return GLSupport.gl33;
+        return false;
     }
 }

--- a/source/bindbc/opengl/bind/gl41.d
+++ b/source/bindbc/opengl/bind/gl41.d
@@ -12,13 +12,13 @@ static if(glSupport >= GLSupport.gl41) {
     import bindbc.opengl.context;
 
     package(bindbc.opengl) @nogc nothrow
-    GLSupport loadGL41(SharedLib lib, GLSupport contextVersion)
+    bool loadGL41(SharedLib lib, GLSupport contextVersion)
     {
         import bindbc.opengl.bind.arb : loadARB41;
 
         if(contextVersion >= GLSupport.gl41) {
-            if(errorCountGL() == 0 && loadARB41(lib, contextVersion)) return GLSupport.gl41;
+            if(errorCountGL() == 0 && loadARB41(lib, contextVersion)) return true;
         }
-        return GLSupport.gl40;
+        return false;
     }
 }

--- a/source/bindbc/opengl/bind/gl42.d
+++ b/source/bindbc/opengl/bind/gl42.d
@@ -23,13 +23,13 @@ static if(glSupport >= GLSupport.gl42) {
     }
 
     package(bindbc.opengl) @nogc nothrow
-    GLSupport loadGL42(SharedLib lib, GLSupport contextVersion)
+    bool loadGL42(SharedLib lib, GLSupport contextVersion)
     {
         import bindbc.opengl.bind.arb : loadARB42;
 
         if(contextVersion >= GLSupport.gl42) {
-            if(errorCountGL() == 0 && loadARB42(lib, contextVersion)) return GLSupport.gl42;
+            if(errorCountGL() == 0 && loadARB42(lib, contextVersion)) return true;
         }
-        return GLSupport.gl41;
+        return false;
     }
 }

--- a/source/bindbc/opengl/bind/gl43.d
+++ b/source/bindbc/opengl/bind/gl43.d
@@ -59,7 +59,7 @@ static if(glSupport >= GLSupport.gl43) {
     }
 
     package(bindbc.opengl) @nogc nothrow
-    GLSupport loadGL43(SharedLib lib, GLSupport contextVersion)
+    bool loadGL43(SharedLib lib, GLSupport contextVersion)
     {
         import bindbc.opengl.bind.arb : loadARB43;
 
@@ -69,8 +69,8 @@ static if(glSupport >= GLSupport.gl43) {
             lib.bindGLSymbol(cast(void**)&glDebugMessageCallback, "glDebugMessageCallback");
             lib.bindGLSymbol(cast(void**)&glGetDebugMessageLog, "glGetDebugMessageLog");
 
-            if(errorCountGL() == 0 && loadARB43(lib, contextVersion)) return GLSupport.gl43;
+            if(errorCountGL() == 0 && loadARB43(lib, contextVersion)) return true;
         }
-        return GLSupport.gl42;
+        return false;
     }
 }

--- a/source/bindbc/opengl/bind/gl44.d
+++ b/source/bindbc/opengl/bind/gl44.d
@@ -18,13 +18,13 @@ static if(glSupport >= GLSupport.gl44) {
     }
 
     package(bindbc.opengl) @nogc nothrow
-    GLSupport loadGL44(SharedLib lib, GLSupport contextVersion)
+    bool loadGL44(SharedLib lib, GLSupport contextVersion)
     {
         import bindbc.opengl.bind.arb : loadARB44;
 
         if(contextVersion >= GLSupport.gl44) {
-            if(errorCountGL() == 0 && loadARB44(lib, contextVersion)) return GLSupport.gl43;
+            if(errorCountGL() == 0 && loadARB44(lib, contextVersion)) return true;
         }
-        return GLSupport.gl43;
+        return false;
     }
 }

--- a/source/bindbc/opengl/bind/gl45.d
+++ b/source/bindbc/opengl/bind/gl45.d
@@ -27,7 +27,7 @@ static if(glSupport >= GLSupport.gl45) {
     }
 
     package(bindbc.opengl) @nogc nothrow
-    GLSupport loadGL45(SharedLib lib, GLSupport contextVersion)
+    bool loadGL45(SharedLib lib, GLSupport contextVersion)
     {
         import bindbc.opengl.bind.arb : loadARB45;
 
@@ -36,8 +36,8 @@ static if(glSupport >= GLSupport.gl45) {
             lib.bindGLSymbol(cast(void**)&glGetnCompressedTexImage, "glGetnCompressedTexImage");
             lib.bindGLSymbol(cast(void**)&glGetnUniformdv, "glGetnUniformdv");
 
-            if(errorCountGL() == 0 && loadARB45(lib, contextVersion)) return GLSupport.gl45;
+            if(errorCountGL() == 0 && loadARB45(lib, contextVersion)) return true;
         }
-        return GLSupport.gl44;
+        return false;
     }
 }

--- a/source/bindbc/opengl/bind/gl46.d
+++ b/source/bindbc/opengl/bind/gl46.d
@@ -47,7 +47,7 @@ static if(glSupport >= GLSupport.gl46) {
     }
 
     package(bindbc.opengl) @nogc nothrow
-    GLSupport loadGL46(SharedLib lib, GLSupport contextVersion)
+    bool loadGL46(SharedLib lib, GLSupport contextVersion)
     {
         import bindbc.opengl.bind.arb : loadARB46;
 
@@ -56,8 +56,8 @@ static if(glSupport >= GLSupport.gl46) {
             lib.bindGLSymbol(cast(void**)&glMultiDrawArraysIndirectCount, "glMultiDrawArraysIndirectCount");
             lib.bindGLSymbol(cast(void**)&glMultiDrawElementsIndirectCount, "glMultiDrawElementsIndirectCount");
 
-            if(errorCountGL() == 0 && loadARB46(lib, contextVersion)) return GLSupport.gl46;
+            if(errorCountGL() == 0 && loadARB46(lib, contextVersion)) return true;
         }
-        return GLSupport.gl45;
+        return false;
     }
 }

--- a/source/bindbc/opengl/gl.d
+++ b/source/bindbc/opengl/gl.d
@@ -82,34 +82,34 @@ GLSupport loadOpenGL(const(char)* libName)
     if(!lib.loadGL11()) return GLSupport.badLibrary;
     else loadedVersion = GLSupport.gl11;
 
-    // Now load the context-dependent stuff. Always try to load up to
-    // OpenGL 2.1 by default. Load higher only if configured to do so.
-    loadedVersion = lib.loadGL21(contextVersion);
-    static if(glSupport >= GLSupport.gl30) loadedVersion = lib.loadGL30(contextVersion);
-    static if(glSupport >= GLSupport.gl31) loadedVersion = lib.loadGL31(contextVersion);
-    static if(glSupport >= GLSupport.gl32) loadedVersion = lib.loadGL32(contextVersion);
-    static if(glSupport >= GLSupport.gl33) loadedVersion = lib.loadGL33(contextVersion);
-    static if(glSupport >= GLSupport.gl40) loadedVersion = lib.loadGL40(contextVersion);
-    static if(glSupport >= GLSupport.gl41) loadedVersion = lib.loadGL41(contextVersion);
-    static if(glSupport >= GLSupport.gl42) loadedVersion = lib.loadGL42(contextVersion);
-    static if(glSupport >= GLSupport.gl43) loadedVersion = lib.loadGL43(contextVersion);
-    static if(glSupport >= GLSupport.gl44) loadedVersion = lib.loadGL44(contextVersion);
-    static if(glSupport >= GLSupport.gl45) loadedVersion = lib.loadGL45(contextVersion);
-    static if(glSupport >= GLSupport.gl46) loadedVersion = lib.loadGL46(contextVersion);
+    // Now load the context-dependent stuff. `glSupport` is set to OpenGL 2.1
+    // by default and can't be lower. Load higher only if configured to do so.
+    with (GLSupport)
+    static foreach(ver; [ gl12, gl13, gl14, gl15, gl20, gl21, gl30, gl31,
+        gl32, gl33, gl40, gl41, gl42, gl43, gl44, gl45, gl46 ])
+    {
+        static if(ver <= glSupport)
+        {
+            // lib.loadGL30(contextVersion)
+            if(mixin("lib.loadGL" ~ (cast(int)ver).stringof ~ "(contextVersion)"))
+                loadedVersion = ver;
+            else
+                goto LoadARB;
+        }
+    }
+
+    LoadARB:
 
     // From any GL versions higher than the one loaded, load the core ARB
     // extensions.
-    if(loadedVersion < GLSupport.gl30) lib.loadARB30(loadedVersion);
-    if(loadedVersion < GLSupport.gl31) lib.loadARB31(loadedVersion);
-    if(loadedVersion < GLSupport.gl32) lib.loadARB32(loadedVersion);
-    if(loadedVersion < GLSupport.gl33) lib.loadARB33(loadedVersion);
-    if(loadedVersion < GLSupport.gl40) lib.loadARB40(loadedVersion);
-    if(loadedVersion < GLSupport.gl41) lib.loadARB41(loadedVersion);
-    if(loadedVersion < GLSupport.gl42) lib.loadARB42(loadedVersion);
-    if(loadedVersion < GLSupport.gl43) lib.loadARB43(loadedVersion);
-    if(loadedVersion < GLSupport.gl44) lib.loadARB44(loadedVersion);
-    if(loadedVersion < GLSupport.gl45) lib.loadARB45(loadedVersion);
-    if(loadedVersion < GLSupport.gl46) lib.loadARB46(loadedVersion);
+    with (GLSupport)
+    static foreach(ver; [ gl30, gl31, gl32, gl33, gl40, gl41, gl42, gl43,
+        gl44, gl45, gl46 ])
+    {
+        if(ver > loadedVersion)
+            // lib.loadARB30(contextVersion)
+            mixin("lib.loadARB" ~ (cast(int)ver).stringof ~ "(loadedVersion);");
+    }
 
     // Load all other supported extensions
     loadARB(lib, contextVersion);

--- a/source/bindbc/opengl/gl.d
+++ b/source/bindbc/opengl/gl.d
@@ -80,10 +80,11 @@ GLSupport loadOpenGL(const(char)* libName)
 
     // Load the base library
     if(!lib.loadGL11()) return GLSupport.badLibrary;
+    else loadedVersion = GLSupport.gl11;
 
     // Now load the context-dependent stuff. Always try to load up to
     // OpenGL 2.1 by default. Load higher only if configured to do so.
-    auto loadedVersion = lib.loadGL21(contextVersion);
+    loadedVersion = lib.loadGL21(contextVersion);
     static if(glSupport >= GLSupport.gl30) loadedVersion = lib.loadGL30(contextVersion);
     static if(glSupport >= GLSupport.gl31) loadedVersion = lib.loadGL31(contextVersion);
     static if(glSupport >= GLSupport.gl32) loadedVersion = lib.loadGL32(contextVersion);


### PR DESCRIPTION
I suppose you load versions incorrectly. For example, a program uses GL_43, but runs on a hardware, that supports only 3.2. After this code
```D
loadedVersion = lib.loadGL21(contextVersion);
static if(glSupport >= GLSupport.gl30) loadedVersion = lib.loadGL30(contextVersion);
static if(glSupport >= GLSupport.gl31) loadedVersion = lib.loadGL31(contextVersion);
static if(glSupport >= GLSupport.gl32) loadedVersion = lib.loadGL32(contextVersion);
static if(glSupport >= GLSupport.gl33) loadedVersion = lib.loadGL33(contextVersion);
static if(glSupport >= GLSupport.gl40) loadedVersion = lib.loadGL40(contextVersion);
static if(glSupport >= GLSupport.gl41) loadedVersion = lib.loadGL41(contextVersion);
static if(glSupport >= GLSupport.gl42) loadedVersion = lib.loadGL42(contextVersion);
static if(glSupport >= GLSupport.gl43) loadedVersion = lib.loadGL43(contextVersion);
```
our `loadedVersion` will be equal to gl42.

So, I rewrote this process to just stop on the first failing version. Functions loadGL**, I guess, should be separated from each other and return only success-failure code.

`static foreach` was added in 2.076.0, does bindbc need to support lower versions?