### PR TITLE
Add missing nogc and nothrow attributes

### DIFF
--- a/source/bindbc/opengl/bind/arb/core_42.d
+++ b/source/bindbc/opengl/bind/arb/core_42.d
@@ -80,7 +80,7 @@ static if(useARBInternalFormatQuery) {
     bool hasARBInternalFormatQuery() { return _hasARBInternalFormatQuery; }
 
     enum uint GL_NUM_SAMPLE_COUNTS = 0x9380;
-    extern(System)  alias pglGetInternalformativ = void function(GLenum, GLenum, GLenum, GLsizei, GLint*);
+    extern(System) @nogc nothrow alias pglGetInternalformativ = void function(GLenum, GLenum, GLenum, GLsizei, GLint*);
     __gshared pglGetInternalformativ glGetInternalformativ;
 
     private @nogc nothrow
@@ -146,7 +146,7 @@ static if(useARBShaderAtomicCounters) {
         GL_UNSIGNED_INT_ATOMIC_COUNTER    = 0x92DB,
     }
 
-    extern(System)  alias pglGetActiveAtomicCounterBufferiv = void function(GLuint, GLuint, GLenum, GLint*);
+    extern(System) @nogc nothrow alias pglGetActiveAtomicCounterBufferiv = void function(GLuint, GLuint, GLenum, GLint*);
     __gshared pglGetActiveAtomicCounterBufferiv glGetActiveAtomicCounterBufferiv;
 
     private @nogc nothrow


### PR DESCRIPTION
`glGetInternalformativ` and `glGetActiveAtomicCounterBufferiv` declarations are not `@nogc` `nothrow`.

The only other `extern(System)` declarations that are not followed immediately by a `@nogc` are `GLDEBUGPROC`, `GLDEBUGPROCARB` and `GLDEBUGPROCAMD`.

```D
extern(System) nothrow alias GLDEBUGPROC = void function(GLenum,GLenum,GLuint,GLenum,GLsizei,const(GLchar)*,GLvoid*);
 ```
In `bind/arb/core_43.d` and `bind/arb/arb_01.d`.

These arguably should be `@nogc` because OpenGL might call the callback from a thread not owned by Druntime.

On the other hand, if you `glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS)` the callback will be called in the same thread as the context guaranteed, so in that case the user might want to use the GC in the callback.

For now I left the debug callbacks as is.