### PR TITLE
Add support for ARB_sparse_texture, ARB_sparse_texture2, and ARB_sparse_texture_clamp

### DIFF
--- a/source/bindbc/opengl/bind/arb/arb_01.d
+++ b/source/bindbc/opengl/bind/arb/arb_01.d
@@ -677,6 +677,16 @@ static if(useARBSparseTexture2) {
     bool hasARBSparseTexture2() { return _hasARBSparseTexture2; }
 }
 
+// ARB_sparse_texture_clamp
+version(GL_ARB) enum useARBSparseTextureClamp = true;
+else version(GL_ARB_sparse_texture_clamp) enum useARBSparseTextureClamp = true;
+else enum useARBSparseTextureClamp = false;
+
+static if(useARBSparseTextureClamp) {
+    private bool _hasARBSparseTextureClamp;
+    bool hasARBSparseTextureClamp() { return _hasARBSparseTextureClamp; }
+}
+
 package @nogc nothrow
 void loadARB_01(SharedLib lib, GLSupport contextVersion)
 {
@@ -742,5 +752,8 @@ void loadARB_01(SharedLib lib, GLSupport contextVersion)
             lib.loadARBSparseTexture(contextVersion);
 
     static if(useARBSparseTexture2) _hasARBSparseTexture2 =
-        hasExtension(contextVersion, "GL_ARB_sparse_texture2");
+            hasExtension(contextVersion, "GL_ARB_sparse_texture2");
+
+    static if(useARBSparseTextureClamp) _hasARBSparseTextureClamp =
+            hasExtension(contextVersion, "GL_ARB_sparse_texture_clamp");
 }

--- a/source/bindbc/opengl/bind/arb/arb_01.d
+++ b/source/bindbc/opengl/bind/arb/arb_01.d
@@ -610,6 +610,63 @@ static if(useARBTransformFeedbackOverflowQuery) {
 }
 else enum hasARBTransformFeedbackOverflowQuery = false;
 
+// ARB_sparse_texture
+version(GL_ARB) enum useARBSparseTexture = true;
+else version(GL_ARB_sparse_texture) enum useARBSparseTexture = true;
+else enum useARBSparseTexture = false;
+
+static if(useARBSparseTexture) {
+    import bindbc.opengl.bind.arb.core_45 : useARBDirectStateAccess, hasARBDirectStateAccess;
+
+    private bool _hasARBSparseTexture;
+    bool hasARBSparseTexture() { return _hasARBSparseTexture; }
+
+    enum : uint {
+        GL_TEXTURE_SPARSE_ARB          = 0x91A6,
+        GL_VIRTUAL_PAGE_SIZE_INDEX_ARB = 0x91A7,
+
+        GL_NUM_SPARSE_LEVELS_ARB = 0x91AA,
+
+        GL_NUM_VIRTUAL_PAGE_SIZES_ARB = 0x91A8,
+        GL_VIRTUAL_PAGE_SIZE_X_ARB    = 0x9195,
+        GL_VIRTUAL_PAGE_SIZE_Y_ARB    = 0x9196,
+        GL_VIRTUAL_PAGE_SIZE_Z_ARB    = 0x9197,
+
+        GL_MAX_SPARSE_TEXTURE_SIZE_ARB                = 0x9198,
+        GL_MAX_SPARSE_3D_TEXTURE_SIZE_ARB             = 0x9199,
+        GL_MAX_SPARSE_ARRAY_TEXTURE_LAYERS_ARB        = 0x919A,
+        GL_SPARSE_TEXTURE_FULL_ARRAY_CUBE_MIPMAPS_ARB = 0x91A9
+    }
+
+    extern(System) @nogc nothrow {
+        alias pglTexPageCommitmentARB =
+            void function(GLenum,GLint,GLint,GLint,GLint,GLsizei,GLsizei,GLsizei,GLboolean);
+        static if(useARBDirectStateAccess) {
+            alias pglTexturePageCommitmentEXT =
+                void function(GLuint,GLint,GLint,GLint,GLint,GLsizei,GLsizei,GLsizei,GLboolean);
+        }
+    }
+
+    __gshared {
+        pglTexPageCommitmentARB glTexPageCommitmentARB;
+        static if(useARBDirectStateAccess)
+            pglTexturePageCommitmentEXT glTexturePageCommitmentEXT;
+    }
+
+    private @nogc nothrow
+    bool loadARBSparseTexture(SharedLib lib, GLSupport contextVersion)
+    {
+        lib.bindGLSymbol(cast(void**)&glTexPageCommitmentARB, "glTexPageCommitmentARB");
+
+        static if(useARBDirectStateAccess) {
+            if(hasARBDirectStateAccess)
+                lib.bindGLSymbol(cast(void**)&glTexturePageCommitmentEXT, "glTexturePageCommitmentEXT");
+        }
+
+        return resetErrorCountGL();
+    }
+}
+
 package @nogc nothrow
 void loadARB_01(SharedLib lib, GLSupport contextVersion)
 {
@@ -669,4 +726,8 @@ void loadARB_01(SharedLib lib, GLSupport contextVersion)
 
     static if(useARBTransformFeedbackOverflowQuery) _hasARBTransformFeedbackOverflowQuery =
             hasExtension(contextVersion, "GL_ARB_transform_feedback_overflow_query");
+
+    static if(useARBSparseTexture) _hasARBSparseTexture =
+            hasExtension(contextVersion, "GL_ARB_sparse_texture") &&
+            lib.loadARBSparseTexture(contextVersion);
 }

--- a/source/bindbc/opengl/bind/arb/arb_01.d
+++ b/source/bindbc/opengl/bind/arb/arb_01.d
@@ -667,6 +667,16 @@ static if(useARBSparseTexture) {
     }
 }
 
+// ARB_sparse_texture2
+version(GL_ARB) enum useARBSparseTexture2 = true;
+else version(GL_ARB_sparse_texture2) enum useARBSparseTexture2 = true;
+else enum useARBSparseTexture2 = false;
+
+static if(useARBSparseTexture2) {
+    private bool _hasARBSparseTexture2;
+    bool hasARBSparseTexture2() { return _hasARBSparseTexture2; }
+}
+
 package @nogc nothrow
 void loadARB_01(SharedLib lib, GLSupport contextVersion)
 {
@@ -730,4 +740,7 @@ void loadARB_01(SharedLib lib, GLSupport contextVersion)
     static if(useARBSparseTexture) _hasARBSparseTexture =
             hasExtension(contextVersion, "GL_ARB_sparse_texture") &&
             lib.loadARBSparseTexture(contextVersion);
+
+    static if(useARBSparseTexture2) _hasARBSparseTexture2 =
+        hasExtension(contextVersion, "GL_ARB_sparse_texture2");
 }


### PR DESCRIPTION
I am new to this code base and am unsure if I did this correctly; please review carefully. Specific questions to consider before merging:

(1) [The spec](https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_sparse_texture.txt) for ARB_sparse_texture says:

> Note: TexturePageCommitmentEXT is supported if and only if the EXT_direct_state_access or the ARB_direct_state_access extension is supported.

I have tried to reflect this condition in the binding. Did I do so correctly? In particular, is `bindbc.opengl.bind.arb.core_45.hasARBDirectStateAccess` guaranteed to be initialized prior to `loadARB_01` being called?

(2) Should I be adding tests or documentation somewhere, as well?

Thanks for your time.