### PR TITLE
Fix segfault on WSL

### DIFF
--- a/source/bindbc/opengl/context.d
+++ b/source/bindbc/opengl/context.d
@@ -85,7 +85,8 @@ GLSupport getContextVersion(SharedLib lib)
             else {
                 import core.stdc.string : strcmp;
                 import core.stdc.stdlib : getenv;
-                if(strcmp(getenv(sessionTypeEnv), "wayland") == 0) {
+                char* sessionType = getenv(sessionTypeEnv);
+                if(sessionType != null && strcmp(sessionType, "wayland") == 0) {
                     if(libEGL == invalidHandle) {
                         foreach(libName; eglNames) {
                             libEGL = load(libName.ptr);


### PR DESCRIPTION
Check that the return value of `getenv` is not null before we do a `strcmp`.
Will fix Issue #40 and probably #31