### PR TITLE
#48 Continue loading GL stuff if something fails

### DIFF
--- a/source/bindbc/opengl/config.d
+++ b/source/bindbc/opengl/config.d
@@ -31,6 +31,20 @@ enum GLSupport {
 	gl46 = 46,
 }
 
+enum GLLoaded : ubyte {
+	// Version didn't load properly
+	notLoaded = 0,
+
+	// Version loaded properly
+	loaded = 1,
+
+	// For denoting deprecated functionality support, unused for now
+	loadedDeprecated = 2,
+
+	// For denoting ARB support, unused for now
+	loadedARB = 4,
+}
+
 enum glAllowDeprecated = (){
 	version(GL_AllowDeprecated) return true;
 	else return false;


### PR DESCRIPTION
My rough idea on how to fix this problem. Currently, blindly continues loading OpenGL functionality even if something fails.
Sets a `GLLoaded` falg for every version. `GLLoaded` flag is designed as a bitfield to describe loaded things in more detail -- eg denote deprecated/ARB functionality loading.